### PR TITLE
Rewrite theme in kitty's template

### DIFF
--- a/catppuccin.conf
+++ b/catppuccin.conf
@@ -1,39 +1,79 @@
-# main colors
-background #1E1E29
-foreground #D7DAE0
-selection_background #2D293B
-selection_foreground #F0AFE1
-url_color #A4B9EF
-cursor #B3E1A3
+# vim:ft=kitty
 
-# tabs
-active_tab_background #1E1E28
-active_tab_foreground #D7DAE0
-inactive_tab_background #1B1923
+## name: Catppuccin
+## author: Pocco81 (https://github.com/Pocco81)
+## license: MIT
+## upstream: https://github.com/catppuccin/kitty/blob/main/catppuccin.conf
+## blurb: Warm mid-tone dark theme to show off your vibrant self!
+
+# The basic colors
+foreground              #D7DAE0
+background              #1E1E28
+selection_foreground    #F0AFE1
+selection_background    #2D293B
+
+# Cursor colors
+cursor                  #B3E1A3
+cursor_text_color       #1E1E28
+
+# URL underline color when hovering with mouse
+url_color               #A4B9EF
+
+# kitty window border colors
+active_border_color     #F0AFE1
+inactive_border_color   #6E6C7C
+bell_border_color       #EADDA0
+
+# OS Window titlebar colors
+# wayland_titlebar_color system
+# macos_titlebar_color system
+
+#: Tab bar colors
+active_tab_foreground   #D7DAE0
+active_tab_background   #1E1E28
 inactive_tab_foreground #A4B9EF
-tab_bar_background #15121C
+inactive_tab_background #1B1923
+tab_bar_background      #15121C
 
-# --> normal
+# Colors for marks (marked text in the terminal)
 
-# normal
+mark1_foreground #1E1E28
+mark1_background #F7C196
+mark2_foreground #1E1E28
+mark2_background #ECBFBD
+mark3_foreground #1E1E28
+mark3_background #C6AAE8
+
+#: The 16 terminal colors
+
+#: black
 color0 #6E6C7C
-color1 #E28C8C
-color2 #B3E1A3
-color3 #EADDA0
-color4 #A4B9EF
-color5 #C6AAE8
-color6 #F0AFE1
-color7 #D7DAE0
-
-# bright
 color8 #6E6C7C
-color9 #E28C8C
-color10 #B3E1A3
-color11 #EADDA0
-color12 #A4B9EF
-color13 #C6AAE8
-color14 #F0AFE1
-color15 #D7DAE0
 
-color16 #ECBFBD
-color17 #3E4058
+#: red
+color1 #E28C8C
+color9 #E28C8C
+
+#: green
+color2  #B3E1A3
+color10 #B3E1A3
+
+#: yellow
+color3  #EADDA0
+color11 #EADDA0
+
+#: blue
+color4  #A4B9EF
+color12 #A4B9EF
+
+#: magenta
+color5  #C6AAE8
+color13 #C6AAE8
+
+#: cyan
+color6  #F0AFE1
+color14 #F0AFE1
+
+#: white
+color7  #D7DAE0
+color15 #D7DAE0


### PR DESCRIPTION
This simply rewrites the theme to match kitty's [template](https://github.com/kovidgoyal/kitty-themes/blob/master/template.conf). This should make it easy to submit the theme upstream if you feel like it. 

It additionally fixes the background color which had been previously set to `#1E1E29`. I however couldn't find this color in the palette, as showcased at [catppuccin](https://github.com/catppuccin/catppuccin). Lemme know if it should be set to `#1E1E29` again and I'll make that change.