### PR TITLE
fix: Fix issues with theme selector kitten

### DIFF
--- a/frappe.conf
+++ b/frappe.conf
@@ -1,6 +1,6 @@
 # vim:ft=kitty
 
-## name:     Catppuccin Kitty Diff Mocha
+## name:     Catppuccin Kitty Frappe
 ## author:   Catppuccin Org
 ## license:  MIT
 ## upstream: https://github.com/catppuccin/kitty/blob/main/frappe.conf

--- a/latte.conf
+++ b/latte.conf
@@ -1,6 +1,6 @@
 # vim:ft=kitty
 
-## name:     Catppuccin Kitty Diff Mocha
+## name:     Catppuccin Kitty Latte
 ## author:   Catppuccin Org
 ## license:  MIT
 ## upstream: https://github.com/catppuccin/kitty/blob/main/latte.conf

--- a/macchiato.conf
+++ b/macchiato.conf
@@ -1,6 +1,6 @@
 # vim:ft=kitty
 
-## name:     Catppuccin Kitty Diff Mocha
+## name:     Catppuccin Kitty Macchiato
 ## author:   Catppuccin Org
 ## license:  MIT
 ## upstream: https://github.com/catppuccin/kitty/blob/main/macchiato.conf

--- a/mocha.conf
+++ b/mocha.conf
@@ -1,6 +1,6 @@
 # vim:ft=kitty
 
-## name:     Catppuccin Kitty Diff Mocha
+## name:     Catppuccin Kitty Mocha
 ## author:   Catppuccin Org
 ## license:  MIT
 ## upstream: https://github.com/catppuccin/kitty/blob/main/mocha.conf


### PR DESCRIPTION
Kitty's theme selector (`kitty +kitten themes`) gets confused if the names of the themes are the same, and when the names of the individual theme's diff themes and the regular themes are the same. Basically, the theme selector uses the first file it finds with the specified theme name, which are the diff themes, so the actual themes never get selected. To fix this, I made sure all files contain a different theme name.

I also believe they had the same names by accident, and it just didn't surface as most people probably just copy the theme in the main `kitty.conf`, and never notices this.