### PR TITLE
fix: include themes subdirectory in links

### DIFF
--- a/themes/diff-frappe.conf
+++ b/themes/diff-frappe.conf
@@ -3,7 +3,7 @@
 ## name:     Catppuccin Kitty Diff Frappe
 ## author:   Catppuccin Org
 ## license:  MIT
-## upstream: https://github.com/catppuccin/kitty/blob/main/diff-frappe.conf
+## upstream: https://github.com/catppuccin/kitty/blob/main/themes/diff-frappe.conf
 ## blurb:    Soothing pastel theme for the high-spirited!
 
 # text

--- a/themes/diff-latte.conf
+++ b/themes/diff-latte.conf
@@ -3,7 +3,7 @@
 ## name:     Catppuccin Kitty Diff Latte
 ## author:   Catppuccin Org
 ## license:  MIT
-## upstream: https://github.com/catppuccin/kitty/blob/main/diff-latte.conf
+## upstream: https://github.com/catppuccin/kitty/blob/main/themes/diff-latte.conf
 ## blurb:    Soothing pastel theme for the high-spirited!
 
 # text

--- a/themes/diff-macchiato.conf
+++ b/themes/diff-macchiato.conf
@@ -3,7 +3,7 @@
 ## name:     Catppuccin Kitty Diff Macchiato
 ## author:   Catppuccin Org
 ## license:  MIT
-## upstream: https://github.com/catppuccin/kitty/blob/main/diff-macchiato.conf
+## upstream: https://github.com/catppuccin/kitty/blob/main/themes/diff-macchiato.conf
 ## blurb:    Soothing pastel theme for the high-spirited!
 
 # text

--- a/themes/diff-mocha.conf
+++ b/themes/diff-mocha.conf
@@ -3,7 +3,7 @@
 ## name:     Catppuccin Kitty Diff Mocha
 ## author:   Catppuccin Org
 ## license:  MIT
-## upstream: https://github.com/catppuccin/kitty/blob/main/diff-mocha.conf
+## upstream: https://github.com/catppuccin/kitty/blob/main/themes/diff-mocha.conf
 ## blurb:    Soothing pastel theme for the high-spirited!
 
 # text

--- a/themes/frappe.conf
+++ b/themes/frappe.conf
@@ -3,7 +3,7 @@
 ## name:     Catppuccin Kitty Frappe
 ## author:   Catppuccin Org
 ## license:  MIT
-## upstream: https://github.com/catppuccin/kitty/blob/main/frappe.conf
+## upstream: https://github.com/catppuccin/kitty/blob/main/themes/frappe.conf
 ## blurb:    Soothing pastel theme for the high-spirited!
 
 

--- a/themes/latte.conf
+++ b/themes/latte.conf
@@ -3,7 +3,7 @@
 ## name:     Catppuccin Kitty Latte
 ## author:   Catppuccin Org
 ## license:  MIT
-## upstream: https://github.com/catppuccin/kitty/blob/main/latte.conf
+## upstream: https://github.com/catppuccin/kitty/blob/main/themes/latte.conf
 ## blurb:    Soothing pastel theme for the high-spirited!
 
 

--- a/themes/macchiato.conf
+++ b/themes/macchiato.conf
@@ -3,7 +3,7 @@
 ## name:     Catppuccin Kitty Macchiato
 ## author:   Catppuccin Org
 ## license:  MIT
-## upstream: https://github.com/catppuccin/kitty/blob/main/macchiato.conf
+## upstream: https://github.com/catppuccin/kitty/blob/main/themes/macchiato.conf
 ## blurb:    Soothing pastel theme for the high-spirited!
 
 

--- a/themes/mocha.conf
+++ b/themes/mocha.conf
@@ -3,7 +3,7 @@
 ## name:     Catppuccin Kitty Mocha
 ## author:   Catppuccin Org
 ## license:  MIT
-## upstream: https://github.com/catppuccin/kitty/blob/main/mocha.conf
+## upstream: https://github.com/catppuccin/kitty/blob/main/themes/mocha.conf
 ## blurb:    Soothing pastel theme for the high-spirited!
 
 


### PR DESCRIPTION
Links in theme files have the old URLs without the `themes` subdirectory.