### PR TITLE
refactor(template): use hex filter

### DIFF
--- a/templates/diff.tera
+++ b/templates/diff.tera
@@ -1,6 +1,6 @@
 ---
 whiskers:
-  version: "^2.2.0"
+  version: "^2.7.0"
   matrix:
     - flavor
   filename: "themes/diff-{{ flavor.identifier }}.conf"
@@ -30,28 +30,28 @@ margin_fg            #{% if flavor.dark %}{{ subtext0.hex }}{% else %}{{ subtext
 filler_bg            #{{ mantle.hex }}
 
 # 30% red, 70% base
-removed_bg           #{{ red | mix(color=base, amount=0.3) | get(key="hex") }}
+removed_bg           #{{ red | mix(color=base, amount=0.3) | hex }}
 # 50% red, 50% base
-highlight_removed_bg #{{ red | mix(color=base, amount=0.5) | get(key="hex") }}
+highlight_removed_bg #{{ red | mix(color=base, amount=0.5) | hex }}
 # 40% red, 60% base
-removed_margin_bg    #{{ red | mix(color=base, amount=0.4) | get(key="hex") }}
+removed_margin_bg    #{{ red | mix(color=base, amount=0.4) | hex }}
 
 # 30% green, 70% base
-added_bg             #{{ green | mix(color=base, amount=0.3) | get(key="hex") }}
+added_bg             #{{ green | mix(color=base, amount=0.3) | hex }}
 # 50% green, 50% base
-highlight_added_bg   #{{ green | mix(color=base, amount=0.5) | get(key="hex") }}
+highlight_added_bg   #{{ green | mix(color=base, amount=0.5) | hex }}
 # 40% green, 60% base
-added_margin_bg      #{{ red | mix(color=base, amount=0.4) | get(key="hex") }}
+added_margin_bg      #{{ red | mix(color=base, amount=0.4) | hex }}
 
 # mantle
 hunk_margin_bg       #{{ mantle.hex }}
 hunk_bg              #{{ mantle.hex }}
 
 # 40% yellow, 60% base
-search_bg            #{{ yellow | mix(color=base, amount=0.4) | get(key="hex") }}
+search_bg            #{{ yellow | mix(color=base, amount=0.4) | hex }}
 # text
 search_fg            #{{ text.hex }}
 # 30% sky, 70% base
-select_bg            #{{ sky | mix(color=base, amount=0.3) | get(key="hex") }}
+select_bg            #{{ sky | mix(color=base, amount=0.3) | hex }}
 # text
 select_fg            #{{ text.hex }}


### PR DESCRIPTION
Use `hex` filter instead of `get(key="hex")`.
Update whiskers to 2.7.0 (required for `hex` filter).